### PR TITLE
Add a fix for failing tests

### DIFF
--- a/lib/schemata.js
+++ b/lib/schemata.js
@@ -310,7 +310,11 @@ module.exports = function(schema) {
           }
           , function(seriesCallback) {
             // This property has an array subschema that needs validating
-            if ((typeof property.type !== 'undefined') && (typeof property.type.arraySchema !== 'undefined')) {
+            if ((typeof property.type !== 'undefined')
+                && (typeof property.type.arraySchema !== 'undefined')
+                && entityObject[key]
+                && entityObject[key].length > 0) {
+
               var index = 0
 
               async.forEach(entityObject[key], function (i, next) {

--- a/test/schemata.test.js
+++ b/test/schemata.test.js
@@ -2,6 +2,7 @@ var schemata = require('..')
   , validity = require('validity')
   , propertyValidator = require('validity/property-validator')
   , should = require('should')
+  , async = require('async')
 
 function createContactSchema() {
   var schema = schemata({
@@ -558,7 +559,26 @@ describe('schemata', function() {
 
         done()
       })
+    })
 
+    it('does not try and validate array sub-schemas that are falsy or []', function (done) {
+      var schema = createBlogSchema()
+        , model = schema.makeBlank()
+        , testValues = [undefined, null, '', 0, []]
+        , subSchema = schema.schema.comments.type.arraySchema.schema
+
+      subSchema.email.validators = {
+        all: [validity.required]
+      }
+
+      async.forEach(testValues, function (value, next) {
+        model.comments = value
+
+        schema.validate(model, function (error, errors) {
+          errors.should.eql({})
+          next()
+        })
+      }, done)
     })
 
     it('allows error response to be a string instead of Error object', function(done) {


### PR DESCRIPTION
The last pull request broke some tests in Catfish due to `schemata` attempting to iterate over and validate falsy and empty array values.

This has now been fixed and tested directly against Catfish using `npm link`.
