### PR TITLE
Don't use ES5 getter syntax for ES3 env compatibility

### DIFF
--- a/lib/schemata.js
+++ b/lib/schemata.js
@@ -360,9 +360,7 @@ module.exports = function(schema) {
   }
 
   return {
-    get schema() {
-      return schema;
-    },
+    schema: schema,
     makeDefault: makeDefault,
     makeBlank: makeBlank,
     hasTag: hasTag,


### PR DESCRIPTION
Because this is a syntax thing and not a feature it can't be polyfilled :unamused: 
