### PR TITLE
Make sure module gets published in the public npm registry

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "description": "Define, create, and validate your business objects, based on specified schema.",
   "version": "0.0.8",
   "author": "Paul Serby <paul@serby.net>",
+  "publishConfig": {
+    "registry": "http://registry.npmjs.org/"
+  },
   "contributors": [
     {
       "name": "Paul Serby",


### PR DESCRIPTION
This makes sure when you `npm publish` it goes to the public npm registry rather than our private registry.
