### PR TITLE
Ensure subschema validators get called in series

### DIFF
--- a/lib/schemata.js
+++ b/lib/schemata.js
@@ -350,7 +350,7 @@ module.exports = function(schema) {
 
               var index = 0
 
-              async.forEach(entityObject[key], function (i, next) {
+              async.forEachSeries(entityObject[key], function (i, next) {
                 property.type.arraySchema.validate(i, set, tag, function (error, subSchemaArrayErrors) {
                   if (Object.keys(subSchemaArrayErrors).length > 0) {
                     if (!errors[key]) errors[key] = {}


### PR DESCRIPTION
This fixes a bug whereby subschemas that error with async validators
did not come back in the correct order.
