### PR TITLE
Add parent to subschema validators

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "async": "^0.2.10",
     "piton-string-utils": "~0.3",
+    "sigmund": "^1.0.1",
     "validity": "~0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   "dependencies": {
     "async": "^0.2.10",
     "piton-string-utils": "~0.3",
-    "sigmund": "^1.0.1",
     "validity": "~0.0"
   },
   "devDependencies": {

--- a/schemata.js
+++ b/schemata.js
@@ -23,6 +23,7 @@ function createSchemata(schema) {
 
 function Schemata(schema) {
   this.schema = schema || {}
+  Schemata.prototype.validate.prototype.parent = null
 }
 
 /*
@@ -263,11 +264,41 @@ Schemata.prototype.cast = function (entityObject, tag) {
   return newEntity
 }
 
+function validateArgumentStrategies() {
+  function two(validateArgs) {
+    var properties = {}
+    properties.entityObject = validateArgs[0]
+    properties.set = 'all'
+    properties.tag = undefined
+    properties.callback = validateArgs[1]
+    return properties
+  }
+  function three(validateArgs) {
+    var properties = {}
+    properties.entityObject = validateArgs[0]
+    properties.set = validateArgs[1] || 'all'
+    properties.tag = undefined
+    properties.callback = validateArgs[2]
+    return properties
+  }
+  function four(validateArgs) {
+    var properties = {}
+    properties.entityObject = validateArgs[0]
+    properties.set = validateArgs[1] || 'all'
+    properties.tag = validateArgs[2]
+    properties.callback = validateArgs[3]
+    return properties
+  }
+  return {
+    '2': two
+  , '3': three
+  , '4': four
+  }
+}
 /*
  * Validates entity against the specified set, if set is not given the set 'all' will be assumed.
  */
 Schemata.prototype.validate = function (/*entityObject, set, tag, callback*/) {
-
   var errors = {}
     , processedSchema = {}
 
@@ -275,27 +306,16 @@ Schemata.prototype.validate = function (/*entityObject, set, tag, callback*/) {
     , set
     , tag
     , callback
+    , validateStrategy = validateArgumentStrategies()
+    , properties
 
-  switch (arguments.length) {
-  case 2:
-    entityObject = arguments[0]
-    set = 'all'
-    tag = undefined
-    callback = arguments[1]
-    break
-  case 3:
-    entityObject = arguments[0]
-    set = arguments[1] || 'all'
-    tag = undefined
-    callback = arguments[2]
-    break
-  case 4:
-    entityObject = arguments[0]
-    set = arguments[1] || 'all'
-    tag = arguments[2]
-    callback = arguments[3]
-    break
-  default:
+  if (validateStrategy.hasOwnProperty(arguments.length)) {
+    properties = validateStrategy[arguments.length](arguments)
+    entityObject = properties.entityObject
+    set = properties.set
+    tag = properties.tag
+    callback = properties.callback
+  } else {
     throw new Error('Validate called with a bad number of arguments')
   }
 
@@ -304,19 +324,18 @@ Schemata.prototype.validate = function (/*entityObject, set, tag, callback*/) {
     if (hasTag(this.schema, key, tag)) processedSchema[key] = this.schema[key]
   }.bind(this))
 
+  Schemata.prototype.validate.prototype.parent =
+    Schemata.prototype.validate.prototype.parent
+    || entityObject
+
   async.forEach(Object.keys(processedSchema), validateProperty, function (error) {
     callback(error === true ? undefined : error, errors)
   })
-
-  function hash() {
-    return sigmund(arguments, 10)
-  }
 
   /*
    * Run validation on a single property
    */
   function validateProperty(key, propertyCallback) {
-
     var property = processedSchema[key]
       , validateSubschemas = true
 
@@ -337,11 +356,8 @@ Schemata.prototype.validate = function (/*entityObject, set, tag, callback*/) {
 
       async.forEach(validators, function (validator, validateCallback) {
         if (errors[key]) return validateCallback()
-
-        // Check if parent is expected or not
         if (validator.length === 5) {
-          var childHash = hash(entityObject)
-            , parent = this.parentObjects[childHash] || null
+          var parent = Schemata.prototype.validate.prototype.parent
           validator(key, errorName, entityObject, parent, function (error, valid) {
             if (valid) {
               errors[key] = valid
@@ -377,13 +393,6 @@ Schemata.prototype.validate = function (/*entityObject, set, tag, callback*/) {
       if (!isSchemata(type)) return cb()
 
       if (!entityObject[key]) return cb()
-
-      this.parentObjects = this.parentObjects || {}
-
-      // Set parent
-      var childHash = hash(entityObject[key])
-        , parentHash = hash(entityObject)
-      this.parentObjects[childHash] = this.parentObjects[parentHash] || entityObject
 
       return type.validate(entityObject[key], set, tag, function (error, subSchemaErrors) {
         if (Object.keys(subSchemaErrors).length > 0) errors[key] = subSchemaErrors

--- a/schemata.js
+++ b/schemata.js
@@ -16,7 +16,6 @@ var hasTag = require('./lib/has-tag')
 
   , async = require('async')
   , stringUtils = require('piton-string-utils')
-  , sigmund = require('sigmund')
 
 function createSchemata(schema) {
   return new Schemata(schema)

--- a/test/validate-fixtures.js
+++ b/test/validate-fixtures.js
@@ -1,0 +1,12 @@
+module.exports.blog =
+  { title: null
+  , body: null
+  , author:
+      { name: 'test'
+      , age: 0
+      , active: true
+      , phoneNumber: null
+      , dateOfBirth: null
+      }
+  , comments: []
+  }

--- a/test/validate.test.js
+++ b/test/validate.test.js
@@ -437,7 +437,7 @@ describe('#validate()', function() {
     })
   })
 
-  it('should pass the parent to the callback if it takes five arguments and is a subschema', function (done) {
+  it('should pass the parent to callback if it has five arguments and is a subschema', function (done) {
     var schema = createBlogSchema()
       , subSchema = schema.schema.author.type.schema
       , schemaParent
@@ -455,7 +455,7 @@ describe('#validate()', function() {
     })
   })
 
-  it('should pass null as parent to the callback if it takes five arguments and is not a subschema', function (done) {
+  it('should pass the schema as parent to callback if it has five arguments and is not a subschema', function (done) {
     var schema = createBlogSchema()
       , schemaParent
 
@@ -466,8 +466,8 @@ describe('#validate()', function() {
       } ]
     }
 
-    schema.validate(schema.makeDefault({ title: '' }), function() {
-      assert.equal(schemaParent, null, 'Schema parent not null')
+    schema.validate(schema.makeDefault({ author: { name: 'test' } }), function() {
+      schemaParent.should.eql(fixtures.blog, 'Schema parent was not the schema itself')
       done()
     })
   })

--- a/test/validate.test.js
+++ b/test/validate.test.js
@@ -7,6 +7,7 @@ var schemata = require('../')
   , async = require('async')
   , assert = require('assert')
   , createCommentSchema = helpers.createCommentSchema
+  , fixtures = require('./validate-fixtures')
 
 function createBlogSchemaWithSubSchemaNotInitialised() {
   return schemata(
@@ -432,6 +433,41 @@ describe('#validate()', function() {
   it('should not call the callback multiple times when omitting optional args', function (done) {
     var schema = createBlogSchema()
     schema.validate(schema.makeDefault({ comments: [ {}, {} ] }), 'all', function () {
+      done()
+    })
+  })
+
+  it('should pass the parent to the callback if it takes five arguments and is a subschema', function (done) {
+    var schema = createBlogSchema()
+      , subSchema = schema.schema.author.type.schema
+      , schemaParent
+
+    subSchema.name.validators = {
+      all: [ function(key, errorProperty, object, parent, callback) {
+        schemaParent = parent
+        return callback(undefined, object[key] ? undefined : errorProperty + ' is required')
+      } ]
+    }
+
+    schema.validate(schema.makeDefault({ author: { name: 'test' } }), function() {
+      schemaParent.should.eql(fixtures.blog, 'Schema parent was not returned in the callback')
+      done()
+    })
+  })
+
+  it('should pass null as parent to the callback if it takes five arguments and is not a subschema', function (done) {
+    var schema = createBlogSchema()
+      , schemaParent
+
+    schema.schema.title.validators = {
+      all: [ function(key, errorProperty, object, parent, callback) {
+        schemaParent = parent
+        return callback(undefined, object[key] ? undefined : errorProperty + ' is required')
+      } ]
+    }
+
+    schema.validate(schema.makeDefault({ title: '' }), function() {
+      assert.equal(schemaParent, null, 'Schema parent not null')
       done()
     })
   })


### PR DESCRIPTION
Backwards compatible as it only adds the parents in if the validator is expecting 5 arguments instead of the usual 4. It also uses the top-level schema as the parent, rather than only one level up.

Potential issue: Sigmund produces a very basic signature based on the properties and values of an object. There's the possibility that for schemas with common values that there may be a collision.