### PR TITLE
allow subschema objects to be null (not-required)

### DIFF
--- a/schemata.js
+++ b/schemata.js
@@ -201,6 +201,7 @@ Schemata.prototype.stripUnknownProperties = function (entityObject, tag, ignoreT
  * For booleans and integers; undefined, '', and null will all be cast to null
  * For array they will be converted to []
  * For object they will be converted to {}
+ * For sub-schema object they will be converted to the sub-schema default
  *
  * Throws error if type is undefined.
  *
@@ -213,7 +214,9 @@ Schemata.prototype.castProperty = function (type, value) {
   // a sub-schema, or an array of sub-schemas
 
   var subSchema = getType(type, value)
-  if (isSchemata(subSchema)) return subSchema.cast(value)
+  if (isSchemata(subSchema)) {
+    return value !== null ? subSchema.cast(value) : subSchema.makeDefault()
+  }
 
   if (isSchemataArray(type)) {
     if (!value) return null
@@ -227,7 +230,7 @@ Schemata.prototype.castProperty = function (type, value) {
   // cast the value based on which constructor is found
 
   // JSHint doesn't like switch statements!
-  /* jshint maxcomplexity: 12 */
+  /* jshint maxcomplexity: 13 */
   switch (type) {
   case Boolean:
     return castBoolean(value)

--- a/schemata.js
+++ b/schemata.js
@@ -138,7 +138,7 @@ Schemata.prototype.makeDefault = function (existingEntity) {
  */
 Schemata.prototype.stripUnknownProperties = function (entityObject, tag, ignoreTagForSubSchemas) {
 
-  /* jshint maxcomplexity: 9 */
+  /* jshint maxcomplexity: 10 */
 
   var newEntity = {}
 
@@ -152,6 +152,12 @@ Schemata.prototype.stripUnknownProperties = function (entityObject, tag, ignoreT
     if (typeof property === 'undefined' || !hasTag(this.schema, key, tag)) return
 
     var type = getType(property.type, entityObject)
+
+    // If the type is a schemata instance and is null, leave it alone
+    if (isSchemata(type) && entityObject[key] === null) {
+      newEntity[key] = null
+      return
+    }
 
     // If the type is a schemata instance use its stripUnknownProperties() function
     if (isSchemata(type)) {

--- a/schemata.js
+++ b/schemata.js
@@ -201,7 +201,6 @@ Schemata.prototype.stripUnknownProperties = function (entityObject, tag, ignoreT
  * For booleans and integers; undefined, '', and null will all be cast to null
  * For array they will be converted to []
  * For object they will be converted to {}
- * For sub-schema object they will be converted to the sub-schema default
  *
  * Throws error if type is undefined.
  *
@@ -215,7 +214,7 @@ Schemata.prototype.castProperty = function (type, value) {
 
   var subSchema = getType(type, value)
   if (isSchemata(subSchema)) {
-    return value !== null ? subSchema.cast(value) : subSchema.makeDefault()
+    return value !== null ? subSchema.cast(value) : null
   }
 
   if (isSchemataArray(type)) {

--- a/test/cast.test.js
+++ b/test/cast.test.js
@@ -138,14 +138,9 @@ describe('#cast()', function() {
     }
 
     var obj = schema.cast(initialObj)
-    assert.deepEqual(obj.author
-    , { name: null
-      , age: 0
-      , active: true
-      , phoneNumber: null
-      , dateOfBirth: null
-      })
+    assert.strictEqual(obj.author, null)
   })
+
   it('casts properties that are an array of subschemas', function () {
     var schema = createBlogSchema()
       , obj = schema.cast(

--- a/test/cast.test.js
+++ b/test/cast.test.js
@@ -124,6 +124,28 @@ describe('#cast()', function() {
     obj.author.dateOfBirth.should.be.instanceOf(Date)
   })
 
+  it('casts properties that have null subschemas', function () {
+    var schema = createBlogSchema()
+      , initialObj =
+        { title: 'My Blog'
+        , author: null
+        , comments: []
+        }
+
+    schema.schema.author.type = function (model) {
+      assert.deepEqual(model, initialObj.author)
+      return createContactSchema()
+    }
+
+    var obj = schema.cast(initialObj)
+    assert.deepEqual(obj.author
+    , { name: null
+      , age: 0
+      , active: true
+      , phoneNumber: null
+      , dateOfBirth: null
+      })
+  })
   it('casts properties that are an array of subschemas', function () {
     var schema = createBlogSchema()
       , obj = schema.cast(

--- a/test/strip-unknown-properties.test.js
+++ b/test/strip-unknown-properties.test.js
@@ -31,6 +31,12 @@ describe('#stripUnknownProperties()', function() {
       .should.eql({ author: { name: 'Paul' } })
   })
 
+  it('does not attempt to strip properties from null sub-schema objects', function() {
+    var schema = createBlogSchema()
+    schema.stripUnknownProperties({ author: null })
+      .should.eql({ author: null })
+  })
+
   it('strips out properties from sub-schemas returned from a type function', function() {
     var schema = createBlogSchema()
       , obj = { author: { name: 'Paul', extra: 'Not here' } }


### PR DESCRIPTION
I have an optional sub-schema property in my schema, if I do not set it I get the following error:

```sh
Object.keys called on non-object
    TypeError: Object.keys called on non-object
        at Function.keys (native)
        at Schemata.stripUnknownProperties (/private/var/application/EchoLocation/TalentBooking/node_modules/schemata/schemata.js:147:10)
        at Schemata.<anonymous> (/private/var/application/EchoLocation/TalentBooking/node_modules/schemata/schemata.js:161:29)
        at Array.forEach (native)
        at Schemata.stripUnknownProperties (/private/var/application/EchoLocation/TalentBooking/node_modules/schemata/schemata.js:147:29)
        at Schemata.<anonymous> (/private/var/application/EchoLocation/TalentBooking/node_modules/schemata/schemata.js:183:37)
        at Array.forEach (native)
        at Schemata.<anonymous> (/private/var/application/EchoLocation/TalentBooking/node_modules/schemata/schemata.js:181:25)
        at Array.forEach (native)
        at Schemata.stripUnknownProperties (/private/var/application/EchoLocation/TalentBooking/node_modules/schemata/schemata.js:147:29)
```

I've fixed this by updating `stripUnknownProperties()` so that it ignores null properties.

~~I wasn't sure if casting `null` to the default was better than leaving it as `null`, but chose to do it as null objects are already cast to `{}` so this follows that behaviour.~~

I am now leaving null subobjects null as casting to their default values messes around with required valdation.