### PR TITLE
Alter parents to not use prototypes

### DIFF
--- a/test/validate-fixtures.js
+++ b/test/validate-fixtures.js
@@ -10,3 +10,28 @@ module.exports.blog =
       }
   , comments: []
   }
+
+module.exports.expectedParents =
+  [ { 'title': null
+    , 'body': null
+    , 'author':
+      { 'name': 'Terry Pratchett'
+      , 'age': 66
+      , 'active': false
+      , 'phoneNumber': null
+      , 'dateOfBirth': null
+      }
+    ,'comments': []
+    }
+  , { 'title': null
+    , 'body': null
+    , 'author':
+      { 'name': 'Stephen King'
+      , 'age': 68
+      , 'active': true
+      , 'phoneNumber': null
+      , 'dateOfBirth': null
+      }
+    , 'comments': []
+    }
+  ]


### PR DESCRIPTION
The use of prototype for the parent caused repeated validates on the same schemata object, but with different passed objects to return the parent of the first passed object. The validate function has been changed to set the parent, and then begin the recursive validation that it originally did, but with this parent passed to it.

Originally noticed by @balaclark.