### PR TITLE
don't makeDefault() on sub-schema properties with null values

### DIFF
--- a/schemata.js
+++ b/schemata.js
@@ -85,6 +85,8 @@ Schemata.prototype.makeBlank = function () {
  */
 Schemata.prototype.makeDefault = function (existingEntity) {
 
+  /* jshint maxcomplexity: 7 */
+
   var newEntity = this.makeBlank()
 
   if (!existingEntity) existingEntity = {}
@@ -94,6 +96,12 @@ Schemata.prototype.makeDefault = function (existingEntity) {
     var property = this.schema[key]
       , existingValue = existingEntity[key]
       , type = getType(property.type, existingEntity)
+
+    // If the property is a schemata instance and has no existing value, set value to null
+    if (isSchemata(type) && (existingValue === null || existingValue === undefined)) {
+      newEntity[key] = null
+      return
+    }
 
     // If the property is a schemata instance use its makeDefault() function
     if (isSchemata(type)) {

--- a/test/make-default.test.js
+++ b/test/make-default.test.js
@@ -54,7 +54,7 @@ describe('#makeDefault()', function() {
       })
   })
 
-  it('creates defaults for sub-schema', function() {
+  it('should not create default values on subschemas when value is null', function() {
     var schema = createBlogSchema()
     schema.makeDefault({ author: null }).should.eql(
       { title: null

--- a/test/make-default.test.js
+++ b/test/make-default.test.js
@@ -49,7 +49,17 @@ describe('#makeDefault()', function() {
     schema.makeDefault().should.eql(
       { title: null
       , body: null
-      , author: { name: null, age: 0, active: true, phoneNumber: null, dateOfBirth: null }
+      , author: null
+      , comments: []
+      })
+  })
+
+  it('creates defaults for sub-schema', function() {
+    var schema = createBlogSchema()
+    schema.makeDefault({ author: null }).should.eql(
+      { title: null
+      , body: null
+      , author: null
       , comments: []
       })
   })

--- a/test/make-default.test.js
+++ b/test/make-default.test.js
@@ -64,6 +64,16 @@ describe('#makeDefault()', function() {
       })
   })
 
+  it('should not create default values on subschemas when value is undefined', function() {
+    var schema = createBlogSchema()
+    schema.makeDefault({ author: undefined }).should.eql(
+      { title: null
+      , body: null
+      , author: null
+      , comments: []
+      })
+  })
+
   it('extends given object correctly for sub-schemas', function() {
     var schema = createBlogSchema()
     schema.makeDefault(


### PR DESCRIPTION
This is causing validation errors when I try to save an object with non-required sub-schema property set to `null`.

This also brings sub-schema `makeDefault()` into line with how sub-schema `cast()` works (see https://github.com/serby/schemata/commit/caed73086f2abe6c9bed279c4ae2feba5a6db575).