### PR TITLE
Check that defaultValue is a function or primitive type, fixes #32

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   ],
   "dependencies": {
     "async": "^0.2.10",
+    "is-primitive": "^2.0.0",
     "piton-string-utils": "~0.3",
     "validity": "~0.0"
   },

--- a/schemata.js
+++ b/schemata.js
@@ -16,6 +16,7 @@ var hasTag = require('./lib/has-tag')
 
   , async = require('async')
   , stringUtils = require('piton-string-utils')
+  , isPrimitive = require('is-primitive')
 
 function createSchemata(schema) {
   return new Schemata(schema)
@@ -23,6 +24,12 @@ function createSchemata(schema) {
 
 function Schemata(schema) {
   this.schema = schema || {}
+  Object.keys(this.schema).forEach(function (k) {
+    if (!schema[k].defaultValue) return
+    if (typeof schema[k].defaultValue === 'function') return
+    if (isPrimitive(schema[k].defaultValue)) return
+    throw new Error('Schema property "' + k + '" must be either a primitive value or a function')
+  }.bind(this))
 }
 
 /*

--- a/schemata.js
+++ b/schemata.js
@@ -28,7 +28,7 @@ function Schemata(schema) {
     if (!schema[k].defaultValue) return
     if (typeof schema[k].defaultValue === 'function') return
     if (isPrimitive(schema[k].defaultValue)) return
-    throw new Error('Schema property "' + k + '" must be either a primitive value or a function')
+    throw new Error('Schema property "' + k + '"’s defaultValue must be either a primitive value or a function')
   }.bind(this))
 }
 

--- a/schemata.js
+++ b/schemata.js
@@ -28,7 +28,8 @@ function Schemata(schema) {
     if (!schema[k].defaultValue) return
     if (typeof schema[k].defaultValue === 'function') return
     if (isPrimitive(schema[k].defaultValue)) return
-    throw new Error('Schema property "' + k + '"’s defaultValue must be either a primitive value or a function')
+    throw new Error('The defaultValue for the schema property "' +
+      k + '" must be either a primitive value or a function')
   }.bind(this))
 }
 

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -2,9 +2,35 @@ var schemata = require('../')
 
 describe('#schema', function() {
 
-  it('schema should be empty for a default schemata', function() {
+  it('should default to an empty schemata', function() {
     var empty = schemata()
     empty.schema.should.eql({})
+  })
+
+  it('should throw an error if a defaultValue is neither a primitive value or a function', function () {
+
+    var badSchemas =
+          [ { a: { defaultValue: [] } }
+          , { a: { defaultValue: {} } }
+          , { a: { defaultValue: new Date() } }
+          , { a: { defaultValue: 1 }, b: { defaultValue: [] } }
+          ]
+      , goodSchemas =
+          [ { a: { defaultValue: function () { return [] } } }
+          , { a: { defaultValue: null } }
+          , { a: { defaultValue: undefined } }
+          , { a: { defaultValue: 'Hi' } }
+          , { a: { defaultValue: 20 } }
+          ]
+
+    badSchemas.forEach(function (s) {
+      (function () { schemata(s) }).should.throw()
+    })
+
+    goodSchemas.forEach(function (s) {
+      (function () { schemata(s) }).should.not.throw()
+    })
+
   })
 
 })


### PR DESCRIPTION
This checks in the constructor that all of the `defaultValue`s on the schema properties are either 'primitive' or functions.

The only case where this won't help is in some of our applications I've seen the internal `schemata.schema` updated. In that case the check has already happened, so it would be possible to get the schema into an invalid state. But that is no worse than the current situation.
