### PR TITLE
Fix a bug casting dynamic subschemas

### DIFF
--- a/schemata.js
+++ b/schemata.js
@@ -215,14 +215,14 @@ Schemata.prototype.stripUnknownProperties = function (entityObject, tag, ignoreT
  * Throws error if type is undefined.
  *
  */
-Schemata.prototype.castProperty = function (type, value) {
+Schemata.prototype.castProperty = function (type, value, key, entityObject) {
 
   if (type === undefined) throw new Error('Missing type')
 
   // First check whether the type of this property is
   // a sub-schema, or an array of sub-schemas
 
-  var subSchema = getType(type, value)
+  var subSchema = getType(type, entityObject)
   if (isSchemata(subSchema)) {
     return value !== null ? subSchema.cast(value) : null
   }
@@ -274,7 +274,7 @@ Schemata.prototype.cast = function (entityObject, tag) {
 
     // Only cast properties in the schema and tagged, if tag is provided
     if (this.schema[key] !== undefined && this.schema[key].type && hasTag(this.schema, key, tag)) {
-      newEntity[key] = this.castProperty(this.schema[key].type, entityObject[key])
+      newEntity[key] = this.castProperty(this.schema[key].type, entityObject[key], key, entityObject)
     }
 
   }.bind(this))

--- a/test/cast.test.js
+++ b/test/cast.test.js
@@ -177,8 +177,13 @@ describe('#cast()', function() {
         , tyreWear: { nearsideFront: '0', offsideFront: '2', nearsideBack: '3', offsideBack: '5' }
         })
 
-    assert.deepStrictEqual(bike.tyreWear, { front: 0, back: 2 })
-    assert.deepStrictEqual(car.tyreWear, { nearsideFront: 0, offsideFront: 2, nearsideBack: 3, offsideBack: 5 })
+    assert.strictEqual(bike.tyreWear.front, 0)
+    assert.strictEqual(bike.tyreWear.back, 2)
+
+    should.strictEqual(car.tyreWear.nearsideFront, 0)
+    should.strictEqual(car.tyreWear.offsideFront, 2)
+    should.strictEqual(car.tyreWear.nearsideBack, 3)
+    should.strictEqual(car.tyreWear.offsideBack, 5)
 
   })
 


### PR DESCRIPTION
The `getType(type, obj)` function expects an entire object
as the second argument. Inside the `castProperty()` function
however, it was only getting a single property value.

A failing test is included, now which passes. Two other tests
relied on this broken functionality, so they were fixed too.

I thought the cleanest thing to do would be change the method
signature of castProperty to `fn(type, key, obj)`, but although
that means less repetition and a simpler signature it would break
compatibility. Since `castProperty()` is a public method (and I
know is used with the signature `fn(type, value)` it's best to
leave that alone.