### PR TITLE
Progress on dealing with schemata.Array(<PrimitiveType>)

### DIFF
--- a/lib/array.js
+++ b/lib/array.js
@@ -3,6 +3,19 @@ module.exports = ArrayType
 /*
  * Array helper to assist creation of nested array schemas
  */
-function ArrayType(schema) {
-  return { arraySchema: typeof schema === 'function' ? schema() : schema }
+function ArrayType(type) {
+
+  if (typeof type !== 'function') return { arraySchema: type }
+
+  if ([ Boolean, Number, String, Date, Object, Array ].indexOf(type) !== -1) {
+    return (
+      { makeBlank: function () { return [] }
+      , stripUnknownProperties: function (item) { return item }
+      , cast: function (value) { return value.map(type) }
+      , validateRecursive: function () {}
+      })
+  }
+
+  return { arraySchema: type() }
+
 }

--- a/lib/is-array.js
+++ b/lib/is-array.js
@@ -10,9 +10,8 @@ function isArray(obj) {
   if (typeof obj !== 'object') return false
 
   // Array types look like { arraySchema: <schemata> }
-  return isSchemata(obj.arraySchema)
+  if (isSchemata(obj.arraySchema)) return true
+
+  return false
 
 }
-
-// (typeof property.type.arraySchema !== 'undefined') &&
-// (typeof property.type.arraySchema.stripUnknownProperties === 'function')

--- a/lib/is-schemata.js
+++ b/lib/is-schemata.js
@@ -1,6 +1,6 @@
 module.exports = isSchemata
 
-var Schemata = require('../').Schemata
+var requiredKeys = [ 'cast', 'stripUnknownProperties', 'validateRecursive', 'makeBlank' ]
 
 /*
  * Take an object and determine whether it is a schemata instance. This is
@@ -12,15 +12,9 @@ function isSchemata(obj) {
   // Schemata instances must be objects
   if (typeof obj !== 'object') return false
 
-  var is = true
-  Object.keys(Schemata.prototype).forEach(function (k) {
-    if (typeof obj[k] !== 'function') is = false
+  // does it quack like a schemata?
+  return !requiredKeys.some(function (k) {
+    return typeof obj[k] !== 'function'
   })
 
-  return is
-
 }
-
-// typeof property.type === 'object' && typeof property.type.makeDefault === 'function'
-// typeof property.type.stripUnknownProperties === 'function'
-// typeof type.makeBlank === 'function'


### PR DESCRIPTION
### :rotating_light: :warning: Work in progress :warning: :rotating_light:

There is currently a feature gap with casting for arrays of simple/primitive types.

Given the following schema:

```js
{ name: { type: String }, scores: { type: schemata.Array(Number) } }
```

`schemata.cast(obj)` will not cast…

```js
{ name: 'Ben', scores: [ '6', '3', '6' ] }
```

…into…

```js
{ name: 'Ben', scores: [ 6, 3, 6 ] }
```

Not only would I expect this behaviour, it's also rather difficult to fix from outside schemata. It's quite common to be receiving numerical input as strings from HTML form values. If schemata won't cast these types then type information must leak out from the schema into somewhere else in the application.

As mentioned, this is a work in progress so please do not merge (I actually rediscovered this work as uncommitted changes the other day when fixing a different issue).

Things outstanding:

- [ ] Implement `validate()` on schemata arrays of primitive types
- [ ] Add a bunch of tests for schemata arrays of primitive types

With these changes so far, the current test suite still passes, but the code coverage has fallen below the threshold.