### PR TITLE
Ensure promisify uses the 'util.promisify' package

### DIFF
--- a/lib/validate.js
+++ b/lib/validate.js
@@ -1,4 +1,4 @@
-const { promisify } = require('util')
+const promisify = require('util.promisify')
 const hasTag = require('./has-tag')
 const isSchemata = require('./is-schemata')
 const isSchemataArray = require('./is-array')


### PR DESCRIPTION
As we weren't using the `util.promisify` package, any usages of promisify in environments where util did not have promisify would not function (e.g. browserify environment)