### PR TITLE
BREAKING:fix: validate should use all set by default if no specific validator exists

### DIFF
--- a/lib/validate.js
+++ b/lib/validate.js
@@ -105,10 +105,12 @@ const validateSimpleProperty = async (
   set = 'all',
   parent
 ) => {
-  const validators =
-    Array.isArray(property.validators) && set === 'all'
-      ? property.validators
-      : property.validators && property.validators[set]
+  var validators
+  if (Array.isArray(property.validators)) {
+    validators = property.validators
+  } else if (property.validators) {
+    validators = property.validators[set] || property.validators.all
+  }
 
   const errorName =
     property.name === undefined

--- a/test/make-blank.test.js
+++ b/test/make-blank.test.js
@@ -75,4 +75,17 @@ describe('#makeBlank()', () => {
     assert.strictEqual(blogA.comments.length, 1)
     assert.strictEqual(blogB.comments.length, 0)
   })
+
+  it('throw for invalid property types', () => {
+    const schema = schemata({
+      name: 'Foo',
+      properties: {
+        images: {
+          type: { foo: 'bar' }
+        }
+      }
+    })
+
+    assert.throws(() => schema.makeBlank(), Error)
+  })
 })

--- a/test/validate.test.js
+++ b/test/validate.test.js
@@ -728,4 +728,22 @@ describe('#validate()', () => {
     )
     assert.deepStrictEqual(errors, { age: 'age Age 18' })
   })
+
+  it('should throw if bad number of arguments', async () => {
+    const properties = createContactSchema().getProperties()
+    assert.deepStrictEqual(properties.name.validators, undefined)
+    const schema = createNamedSchemata(properties)
+
+    await assert.rejects(
+      () =>
+        schema.validate(
+          schema.makeDefault({ name: '' }),
+          'set',
+          'tag',
+          'foo',
+          'bar'
+        ),
+      Error
+    )
+  })
 })

--- a/test/validate.test.js
+++ b/test/validate.test.js
@@ -238,6 +238,71 @@ describe('#validate()', () => {
     })
   })
 
+  it('uses the [all] set shorthand by default', done => {
+    const properties = createContactSchema().getProperties()
+    assert.deepStrictEqual(properties.name.validators, undefined)
+    properties.name.validators = [required]
+    properties.age.validators = {
+      test: [required]
+    }
+
+    const schema = createNamedSchemata(properties)
+
+    schema.validate(
+      schema.makeDefault({ name: '', age: null }),
+      (ignoreError, errors) => {
+        assert.deepStrictEqual(errors, { name: 'Full Name is required' })
+        done()
+      }
+    )
+  })
+
+  it('uses the [all] set by default with validation set', done => {
+    const properties = createContactSchema().getProperties()
+    assert.deepStrictEqual(properties.name.validators, undefined)
+    properties.name.validators = {
+      all: [required]
+    }
+    properties.age.validators = {
+      test: [required]
+    }
+    const schema = createNamedSchemata(properties)
+
+    schema.validate(
+      schema.makeDefault({ name: '', age: null }),
+      'test',
+      (ignoreError, errors) => {
+        assert.deepStrictEqual(errors, {
+          name: 'Full Name is required',
+          age: 'Age is required'
+        })
+        done()
+      }
+    )
+  })
+
+  it('uses the [all] set shorthand by default with validation set', done => {
+    const properties = createContactSchema().getProperties()
+    assert.deepStrictEqual(properties.name.validators, undefined)
+    properties.name.validators = [required]
+    properties.age.validators = {
+      test: [required]
+    }
+    const schema = createNamedSchemata(properties)
+
+    schema.validate(
+      schema.makeDefault({ name: '', age: null }),
+      'test',
+      (ignoreError, errors) => {
+        assert.deepStrictEqual(errors, {
+          name: 'Full Name is required',
+          age: 'Age is required'
+        })
+        done()
+      }
+    )
+  })
+
   it('Validates sub-schemas', () => {
     const properties = createBlogSchema().getProperties()
     const subschemaProperties = properties.author.type.getProperties()


### PR DESCRIPTION
If validators is an array, always run regardless of specified set (because using an array is a shorthand for `{ all: [...] }`)
If validators is an object, use the specified set validator, if it doesn't exist, fall back and use the `all` validator.

Use case:
```
      firstName: {
        type: String,
        validators: {
          all: [required]
        }
      },
      lastName: {
        type: String,
        validators: [required]
      },
      agency: {
        type: String,
        validators: {
          test: [required]
        }
      },
```

In schemata's current state, if you validate `{}` with the `test` set, it will only fail validation on `agency` field.

With these changes, it will correctly fail on all fields.

If you need to disable a validator field, you simply:

```
      agency: {
        type: String,
        validators: {
          all: [],
          test: [required]
        }
      },
```

Or just omit `validators`